### PR TITLE
Docs(tech): add commitlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ within your Preact applications.
 - Biome: Next-generation formatting and linting for a clean and consistent codebase
 - Lefthook: Manages pre-commit hooks for automated checks and formatting
 - Axios: A popular HTTP client library for efficient API communication
+- Commitlint: Enforces consistent commit message formatting
 
 ## Getting Started
 


### PR DESCRIPTION
## Description

PR #13 omitted Commitlint from the technology stack in the README. This PR adds it to address the omission and enhance the existing setup.