### PR TITLE
fix(movie-item): inconsistent width in firefox

### DIFF
--- a/apps/client/src/components/MovieItem.tsx
+++ b/apps/client/src/components/MovieItem.tsx
@@ -23,7 +23,7 @@ export default function MovieItem({
         src={imageUrl}
         alt={alt}
         className={clsx(
-          "h-full hover:scale-110 transition-transform",
+          "h-full max-w-[10rem] hover:scale-110 transition-transform",
           active && "brightness-50",
         )}
       />


### PR DESCRIPTION
Fixes:
- Introduced an issue where movie items maximized in Firefox due to inconsistent behavior of flex-shrink: 0;.
- Resolved the issue by setting a max-width for movie items, ensuring consistent formatting across browsers.